### PR TITLE
feat: implement sprint 2 base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: Backend tests and migrations
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: chamados
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d chamados"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/chamados
+      JWT_SECRET: ci-secret
+      NODE_ENV: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        run: npm run migrate
+
+      - name: Run tests
+        run: npm test
+
+      - name: Generate coverage
+        run: npm run coverage
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  sonarcloud:
+    name: SonarCloud scan
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - frontend
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/chamados
+      JWT_SECRET: ci-secret
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Generate backend coverage
+        run: npm run coverage
+        working-directory: backend
+
+      - name: Run SonarCloud scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ O projeto consiste no desenvolvimento de um sistema web para gerenciamento de ch
 
 ## Tecnologias e stack
 
+- Frontend: React com Vite
 - Backend: Node.js com Express
 - Banco de dados: PostgreSQL
 - Autenticação: JWT
 - Testes: Vitest
+- Qualidade/CI: GitHub Actions e SonarCloud
 
-Observação: nesta Sprint 1, a entrega foi limitada ao backend/API testável, conforme permitido pelo calendário. Frontend, mensageria, containerização e automações ficam para sprints posteriores.
+Observação: Docker, Docker Compose, RabbitMQ e deploy ficam fora da Sprint 2 e serão tratados em sprints posteriores.
 
 ## Entrega 1
 
@@ -71,11 +73,33 @@ As funcionalidades abaixo estao implementadas no backend e podem ser testadas pe
 - PB-05 Listagem dos meus chamados.
 - PB-06 Detalhe de chamado com historico.
 
+## Sprint 2
+
+O foco da Sprint 2 é consolidar a base do produto com segurança, migrations versionadas, CI, métricas de qualidade e protótipo de interface.
+
+Artefatos da Sprint 2:
+
+- [Escopo da Sprint 2](docs/sprints/sprint-2-escopo.md)
+- [Checklist da Sprint 2](docs/sprints/sprint-2-checklist.md)
+- [Sprint 2 Review](docs/sprints/sprint-2-review.md)
+- [Sprint 2 Retrospectiva](docs/sprints/sprint-2-retrospectiva.md)
+- [Sprint 3 Planning](docs/sprints/sprint-3-planning.md)
+- [Requests da Sprint 2](docs/api/sprint-2-requests.http)
+
+Itens demonstráveis:
+
+- API com headers de segurança e limite nas rotas de autenticação.
+- Cadastro público sem permissão para criar técnico/admin.
+- Migration `002_ticket_lifecycle_and_audit.sql`.
+- Protótipo React para login/cadastro, abertura, listagem e detalhe de chamados.
+- CI com testes, migrations, cobertura e build do frontend.
+
 ## Estrutura do projeto
 
 ```text
-backend/   API Node.js + Express, migrations, autenticação, chamados e testes
-docs/      Documentação do projeto, requests de teste e materiais da Sprint 1
+backend/    API Node.js + Express, migrations, autenticação, chamados e testes
+frontend/   Protótipo React + Vite
+docs/       Documentação do projeto, requests de teste e materiais das sprints
 ```
 
 ## Como rodar localmente
@@ -84,6 +108,7 @@ Instalar dependências:
 
 ```bash
 npm run install:backend
+npm run install:frontend
 ```
 
 Rodar backend:
@@ -93,9 +118,21 @@ npm --prefix backend run migrate
 npm --prefix backend run dev
 ```
 
+Rodar frontend:
+
+```bash
+npm run dev:frontend
+```
+
 Rodar testes do backend:
 
 ```bash
 npm test
+```
+
+Rodar build do frontend:
+
+```bash
+npm run build:frontend
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Rodar backend:
 
 ```bash
 npm --prefix backend run migrate
+npm run seed:demo
 npm --prefix backend run dev
 ```
 
@@ -122,6 +123,13 @@ Rodar frontend:
 
 ```bash
 npm run dev:frontend
+```
+
+Credenciais de demonstracao criadas pelo seed:
+
+```text
+Usuario: usuario.demo@example.com / 123456
+Tecnico: tecnico.demo@example.com / 123456
 ```
 
 Rodar testes do backend:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,4 +3,4 @@ PORT=3001
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/chamados
 JWT_SECRET=troque-este-segredo-em-producao
 JWT_EXPIRES_IN=8h
-CORS_ORIGIN=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173,http://127.0.0.1:5173

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,9 +12,10 @@
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.5.2",
+        "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.16.3",
-        "sistema-chamados-suporte": "file:.."
+        "pg": "^8.16.3"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.4",
@@ -23,7 +24,8 @@
     },
     "..": {
       "name": "sistema-chamados-suporte",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1147,9 +1149,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dependencies": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -1159,7 +1161,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -1183,9 +1185,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1471,9 +1473,9 @@
       "dev": true
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1554,13 +1556,13 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -1579,7 +1581,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -1596,6 +1598,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -1840,6 +1859,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1880,6 +1910,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2478,9 +2516,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -2753,10 +2791,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/sistema-chamados-suporte": {
-      "resolved": "..",
-      "link": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,9 +15,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.5.2",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.16.3",
-    "sistema-chamados-suporte": "file:.."
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "node --watch src/server.js",
     "start": "node src/server.js",
     "migrate": "node src/db/migrate.js",
+    "seed:demo": "node src/db/seedDemoUsers.js",
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,5 +1,7 @@
 import cors from 'cors';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 import { env } from './config/env.js';
 import { pool } from './db/pool.js';
 import { errorHandler, notFound } from './middleware/errorHandler.js';
@@ -15,6 +17,8 @@ import { TicketService } from './services/ticketService.js';
 export function createApp(container = buildContainer()) {
   const app = express();
 
+  app.disable('x-powered-by');
+  app.use(helmet());
   app.use(
     cors({
       origin: env.corsOrigin,
@@ -22,6 +26,21 @@ export function createApp(container = buildContainer()) {
     })
   );
   app.use(express.json({ limit: '1mb' }));
+  app.use(
+    '/api/auth',
+    rateLimit({
+      windowMs: 15 * 60 * 1000,
+      limit: 20,
+      standardHeaders: 'draft-8',
+      legacyHeaders: false,
+      message: {
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Muitas tentativas. Tente novamente em alguns minutos.'
+        }
+      }
+    })
+  );
 
   app.get('/health', (_req, res) => {
     res.json({

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -21,7 +21,7 @@ export function createApp(container = buildContainer()) {
   app.use(helmet());
   app.use(
     cors({
-      origin: env.corsOrigin,
+      origin: env.corsOrigins,
       credentials: true
     })
   );

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -2,6 +2,12 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const defaultCorsOrigins = 'http://localhost:5173,http://127.0.0.1:5173';
+const corsOrigins = (process.env.CORS_ORIGIN ?? defaultCorsOrigins)
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? 'development',
   port: Number(process.env.PORT ?? 3001),
@@ -10,5 +16,5 @@ export const env = {
     'postgres://postgres:postgres@localhost:5432/chamados',
   jwtSecret: process.env.JWT_SECRET ?? 'dev-secret-change-me',
   jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? '8h',
-  corsOrigin: process.env.CORS_ORIGIN ?? 'http://localhost:5173'
+  corsOrigins
 };

--- a/backend/src/db/migrations/002_ticket_lifecycle_and_audit.sql
+++ b/backend/src/db/migrations/002_ticket_lifecycle_and_audit.sql
@@ -1,0 +1,24 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;
+
+ALTER TABLE tickets
+ADD COLUMN IF NOT EXISTS due_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_users_last_login_at ON users(last_login_at);
+CREATE INDEX IF NOT EXISTS idx_tickets_updated_at ON tickets(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tickets_due_at ON tickets(due_at);
+CREATE INDEX IF NOT EXISTS idx_ticket_events_created_at ON ticket_events(ticket_id, created_at);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ticket_events_type_check'
+  ) THEN
+    ALTER TABLE ticket_events
+    ADD CONSTRAINT ticket_events_type_check
+    CHECK (type IN ('ticket_created', 'ticket_assigned', 'message_added', 'status_changed'));
+  END IF;
+END $$;

--- a/backend/src/db/seedDemoUsers.js
+++ b/backend/src/db/seedDemoUsers.js
@@ -1,0 +1,49 @@
+import bcrypt from 'bcryptjs';
+import { pool } from './pool.js';
+
+const demoUsers = [
+  {
+    id: '55555555-5555-4555-8555-555555555555',
+    name: 'Usuario Demo',
+    email: 'usuario.demo@example.com',
+    role: 'user'
+  },
+  {
+    id: '66666666-6666-4666-8666-666666666666',
+    name: 'Tecnico Demo',
+    email: 'tecnico.demo@example.com',
+    role: 'technician'
+  }
+];
+
+async function run() {
+  const passwordHash = await bcrypt.hash('123456', 10);
+
+  for (const user of demoUsers) {
+    await pool.query(
+      `
+        INSERT INTO users (id, name, email, password_hash, role)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (email)
+        DO UPDATE SET
+          name = EXCLUDED.name,
+          password_hash = EXCLUDED.password_hash,
+          role = EXCLUDED.role
+      `,
+      [user.id, user.name, user.email, passwordHash, user.role]
+    );
+  }
+
+  console.log('Usuarios de demonstracao atualizados.');
+  console.log('Usuario: usuario.demo@example.com / 123456');
+  console.log('Tecnico: tecnico.demo@example.com / 123456');
+}
+
+run()
+  .catch((error) => {
+    console.error('Falha ao criar usuarios de demonstracao:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/backend/src/repositories/ticketRepository.js
+++ b/backend/src/repositories/ticketRepository.js
@@ -60,6 +60,8 @@ export class TicketRepository {
           t.description,
           t.priority,
           t.status,
+          t.due_at,
+          t.closed_at,
           t.created_at,
           t.updated_at,
           c.id AS category_id,
@@ -90,6 +92,8 @@ export class TicketRepository {
           t.description,
           t.priority,
           t.status,
+          t.due_at,
+          t.closed_at,
           t.created_at,
           t.updated_at,
           c.id AS category_id,
@@ -128,7 +132,13 @@ export class TicketRepository {
     const result = await this.pool.query(
       `
         UPDATE tickets
-        SET status = $2, updated_at = NOW()
+        SET
+          status = $2,
+          closed_at = CASE
+            WHEN $2 IN ('resolved', 'closed') THEN NOW()
+            ELSE NULL
+          END,
+          updated_at = NOW()
         WHERE id = $1
         RETURNING *
       `,
@@ -207,6 +217,8 @@ function mapTicketRow(row) {
     description: row.description,
     priority: row.priority,
     status: row.status,
+    dueAt: row.due_at,
+    closedAt: row.closed_at,
     category: {
       id: row.category_id,
       name: row.category_name
@@ -225,4 +237,3 @@ function mapTicketRow(row) {
     updatedAt: row.updated_at
   };
 }
-

--- a/backend/src/repositories/userRepository.js
+++ b/backend/src/repositories/userRepository.js
@@ -32,7 +32,7 @@ export class UserRepository {
   async findById(id) {
     const result = await this.pool.query(
       `
-        SELECT id, name, email, role, created_at
+        SELECT id, name, email, role, created_at, last_login_at
         FROM users
         WHERE id = $1
       `,
@@ -41,5 +41,15 @@ export class UserRepository {
 
     return result.rows[0] ?? null;
   }
-}
 
+  async markLastLogin(id) {
+    await this.pool.query(
+      `
+        UPDATE users
+        SET last_login_at = NOW()
+        WHERE id = $1
+      `,
+      [id]
+    );
+  }
+}

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -4,8 +4,6 @@ import { randomUUID } from 'node:crypto';
 import { env } from '../config/env.js';
 import { AppError } from '../utils/appError.js';
 
-const VALID_ROLES = new Set(['user', 'technician', 'admin']);
-
 export class AuthService {
   constructor(userRepository) {
     this.userRepository = userRepository;
@@ -15,7 +13,7 @@ export class AuthService {
     const name = String(input.name ?? '').trim();
     const email = normalizeEmail(input.email);
     const password = String(input.password ?? '');
-    const role = VALID_ROLES.has(input.role) ? input.role : 'user';
+    const role = 'user';
 
     if (!name) {
       throw new AppError('Nome e obrigatorio.', 400, 'NAME_REQUIRED');
@@ -57,6 +55,8 @@ export class AuthService {
       throw new AppError('Credenciais invalidas.', 401, 'INVALID_CREDENTIALS');
     }
 
+    await this.userRepository.markLastLogin?.(user.id);
+
     return buildAuthResponse(toPublicUser(user));
   }
 }
@@ -97,4 +97,3 @@ function toPublicUser(user) {
     role: user.role
   };
 }
-

--- a/backend/tests/authService.test.js
+++ b/backend/tests/authService.test.js
@@ -38,6 +38,21 @@ describe('AuthService', () => {
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
+  it('impede cadastro publico com perfil privilegiado', async () => {
+    const repository = new InMemoryUserRepository();
+    const service = new AuthService(repository);
+
+    const result = await service.register({
+      name: 'Tecnico indevido',
+      email: 'tecnico@exemplo.com',
+      password: '123456',
+      role: 'technician'
+    });
+
+    expect(result.user.role).toBe('user');
+    expect(repository.users[0].role).toBe('user');
+  });
+
   it('recusa login com senha incorreta', async () => {
     const repository = new InMemoryUserRepository();
     const service = new AuthService(repository);
@@ -76,5 +91,11 @@ class InMemoryUserRepository {
   async findByEmail(email) {
     return this.users.find((user) => user.email === email) ?? null;
   }
-}
 
+  async markLastLogin(id) {
+    const user = this.users.find((item) => item.id === id);
+    if (user) {
+      user.lastLoginAt = new Date();
+    }
+  }
+}

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      include: ['src/services/**/*.js', 'src/utils/**/*.js'],
+      reporter: ['text', 'lcov'],
+      thresholds: {
+        statements: 70,
+        lines: 70,
+        functions: 80
+      }
+    }
+  }
+});

--- a/docs/api/sprint-2-requests.http
+++ b/docs/api/sprint-2-requests.http
@@ -1,0 +1,29 @@
+@baseUrl = http://localhost:3001
+@token = cole-o-token-aqui
+
+### Health check
+GET {{baseUrl}}/health
+
+### Seguranca - cadastro publico sempre cria usuario comum
+POST {{baseUrl}}/api/auth/register
+Content-Type: application/json
+
+{
+  "name": "Usuario Sprint 2",
+  "email": "usuario.sprint2@example.com",
+  "password": "123456",
+  "role": "technician"
+}
+
+### Login
+POST {{baseUrl}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "usuario.sprint2@example.com",
+  "password": "123456"
+}
+
+### Endpoint autenticado
+GET {{baseUrl}}/api/categories
+Authorization: Bearer {{token}}

--- a/docs/api/sprint-2-requests.http
+++ b/docs/api/sprint-2-requests.http
@@ -9,7 +9,7 @@ POST {{baseUrl}}/api/auth/register
 Content-Type: application/json
 
 {
-  "name": "Usuario Sprint 2",
+  "name": "Usuario Demo",
   "email": "usuario.sprint2@example.com",
   "password": "123456",
   "role": "technician"

--- a/docs/sprints/sprint-1-review.md
+++ b/docs/sprints/sprint-1-review.md
@@ -65,4 +65,4 @@ Com base no que foi entregue na Sprint 1, a Sprint 2 deve priorizar:
 - criar interface para abertura e listagem de chamados;
 - configurar GitHub Actions;
 - integrar SonarCloud;
-- iniciar containerizacao conforme o calendario da Sprint 2.
+- validar prototipo de interface conforme o calendario da Sprint 2.

--- a/docs/sprints/sprint-2-checklist.md
+++ b/docs/sprints/sprint-2-checklist.md
@@ -24,6 +24,7 @@
 | Prototipo de interface validavel | Feito | `frontend/` com React + Vite |
 | Fluxo de login/cadastro | Feito | Tela inicial do prototipo |
 | Fluxo de abertura/listagem/detalhe de chamados | Feito | Dashboard do prototipo |
+| Area do tecnico | Feito | Lista chamados, assume atendimento, responde e altera status |
 | Validacao com usuario/grupo | Pendente | Registrar feedback antes da review |
 
 ## Qualidade

--- a/docs/sprints/sprint-2-checklist.md
+++ b/docs/sprints/sprint-2-checklist.md
@@ -1,0 +1,46 @@
+# Sprint 2 - Checklist
+
+## Seguranca de API
+
+| Exigencia | Status | Evidencia |
+| --- | --- | --- |
+| Revisao de vulnerabilidade em autenticacao | Feito | Cadastro publico sempre gera perfil `user` |
+| Headers HTTP de seguranca | Feito | Middleware `helmet` no Express |
+| Limite de tentativas em autenticacao | Feito | `express-rate-limit` em `/api/auth` |
+| Checklist de seguranca revisado nos PRs | Pendente | A ser conferido nas revisoes dos integrantes |
+
+## Banco de dados e migrations
+
+| Exigencia | Status | Evidencia |
+| --- | --- | --- |
+| Schema versionado com migrations | Feito | `backend/src/db/migrations/001_init.sql` e `002_ticket_lifecycle_and_audit.sql` |
+| Evolucao de modelagem da Sprint 2 | Feito | Campos `last_login_at`, `due_at`, `closed_at` e indices adicionais |
+| Migration executavel localmente | Feito | `npm.cmd --prefix backend run migrate` |
+
+## Interface
+
+| Exigencia | Status | Evidencia |
+| --- | --- | --- |
+| Prototipo de interface validavel | Feito | `frontend/` com React + Vite |
+| Fluxo de login/cadastro | Feito | Tela inicial do prototipo |
+| Fluxo de abertura/listagem/detalhe de chamados | Feito | Dashboard do prototipo |
+| Validacao com usuario/grupo | Pendente | Registrar feedback antes da review |
+
+## Qualidade
+
+| Exigencia | Status | Evidencia |
+| --- | --- | --- |
+| Testes automatizados | Feito | `npm.cmd --prefix backend test` |
+| Cobertura gerada | Feito | `npm.cmd --prefix backend run coverage`, com foco na camada de servicos |
+| CI configurado | Feito | `.github/workflows/ci.yml` |
+| SonarCloud preparado | Feito parcial | `sonar-project.properties`, falta segredo `SONAR_TOKEN` no GitHub |
+
+## Review
+
+| Item | Status |
+| --- | --- |
+| Demo tecnica da API | Pronto |
+| Demo do prototipo React | Pronto |
+| Metricas de qualidade | Em andamento |
+| Retrospectiva da Sprint 2 | Em andamento |
+| Sprint 3 Backlog | Em andamento |

--- a/docs/sprints/sprint-2-escopo.md
+++ b/docs/sprints/sprint-2-escopo.md
@@ -1,0 +1,27 @@
+# Sprint 2 - Escopo
+
+## Objetivo
+
+Consolidar a base da Sprint 1 com foco em seguranca, qualidade, versionamento de banco e prototipo de interface.
+
+## Itens selecionados
+
+| Item | Descricao | Status |
+| --- | --- | --- |
+| SP2-01 | Revisar seguranca da API e corrigir risco de cadastro privilegiado | Implementado |
+| SP2-02 | Adicionar headers HTTP de seguranca e limite em rotas de autenticacao | Implementado |
+| SP2-03 | Evoluir schema com migration versionada da Sprint 2 | Implementado |
+| SP2-04 | Criar prototipo inicial da interface em React | Implementado |
+| SP2-05 | Configurar CI com testes, migrations, build e cobertura | Implementado |
+| SP2-06 | Preparar configuracao para metricas de qualidade no SonarCloud | Implementado parcial |
+| SP2-07 | Validar usabilidade do prototipo com o grupo | Em andamento |
+| SP2-08 | Completar retrospectiva e planejamento da Sprint 3 | Em andamento |
+
+## Fora do escopo desta sprint
+
+- RabbitMQ.
+- Docker e Docker Compose.
+- Deploy em producao.
+- Funcionalidades completas de administracao.
+
+Esses itens ficam para sprints posteriores, conforme planejamento da disciplina.

--- a/docs/sprints/sprint-2-escopo.md
+++ b/docs/sprints/sprint-2-escopo.md
@@ -12,6 +12,7 @@ Consolidar a base da Sprint 1 com foco em seguranca, qualidade, versionamento de
 | SP2-02 | Adicionar headers HTTP de seguranca e limite em rotas de autenticacao | Implementado |
 | SP2-03 | Evoluir schema com migration versionada da Sprint 2 | Implementado |
 | SP2-04 | Criar prototipo inicial da interface em React | Implementado |
+| SP2-09 | Diferenciar interface de solicitante e tecnico | Implementado |
 | SP2-05 | Configurar CI com testes, migrations, build e cobertura | Implementado |
 | SP2-06 | Preparar configuracao para metricas de qualidade no SonarCloud | Implementado parcial |
 | SP2-07 | Validar usabilidade do prototipo com o grupo | Em andamento |

--- a/docs/sprints/sprint-2-retrospectiva.md
+++ b/docs/sprints/sprint-2-retrospectiva.md
@@ -1,0 +1,22 @@
+# Sprint 2 - Retrospectiva
+
+## Start
+
+- Registrar checklist de seguranca em cada PR.
+- Validar fluxos de interface com pelo menos um colega antes do merge.
+- Usar a cobertura e o SonarCloud para priorizar melhoria real de codigo.
+
+## Stop
+
+- Deixar validacoes importantes apenas para a demonstracao final.
+- Abrir PRs grandes demais para uma revisao simples.
+
+## Continue
+
+- Separar as entregas por branches pequenas.
+- Manter commits descritivos no padrao Conventional Commits.
+- Rodar testes localmente antes de abrir PR.
+
+## Observacoes da equipe
+
+Preencher com os aprendizados finais apos a Sprint 2 Review.

--- a/docs/sprints/sprint-2-review.md
+++ b/docs/sprints/sprint-2-review.md
@@ -21,9 +21,10 @@ Demonstrar a consolidacao da base tecnica criada na Sprint 1, com foco em segura
 5. Subir backend e frontend.
 6. Demonstrar cadastro sem login automatico.
 7. Demonstrar login como usuario e login como tecnico usando as credenciais do seed.
-8. Demonstrar abertura, listagem e detalhe de chamado.
-9. Mostrar o workflow de CI no repositorio.
-10. Mostrar o status do SonarCloud, se o token ja estiver configurado.
+8. Demonstrar abertura, listagem e detalhe de chamado como solicitante.
+9. Entrar como tecnico, assumir chamado, responder e alterar status.
+10. Mostrar o workflow de CI no repositorio.
+11. Mostrar o status do SonarCloud, se o token ja estiver configurado.
 
 ## Pontos em andamento
 

--- a/docs/sprints/sprint-2-review.md
+++ b/docs/sprints/sprint-2-review.md
@@ -1,0 +1,31 @@
+# Sprint 2 Review
+
+## Objetivo da review
+
+Demonstrar a consolidacao da base tecnica criada na Sprint 1, com foco em seguranca, qualidade, migrations e prototipo de interface.
+
+## Itens demonstraveis
+
+1. API com cadastro publico limitado ao perfil de usuario comum.
+2. Rotas de autenticacao com limite de tentativas.
+3. Migration `002_ticket_lifecycle_and_audit.sql` aplicada.
+4. Prototipo React consumindo a API.
+5. CI executando testes, migrations, cobertura e build.
+
+## Roteiro sugerido
+
+1. Mostrar o checklist da Sprint 2.
+2. Rodar testes do backend.
+3. Rodar coverage do backend.
+4. Mostrar a migration da Sprint 2.
+5. Subir backend e frontend.
+6. Demonstrar login/cadastro no prototipo.
+7. Demonstrar abertura, listagem e detalhe de chamado.
+8. Mostrar o workflow de CI no repositório.
+9. Mostrar o status do SonarCloud, se o token ja estiver configurado.
+
+## Pontos em andamento
+
+- Validacao formal de usabilidade do prototipo.
+- Leitura final das metricas de qualidade no SonarCloud.
+- Fechamento da retrospectiva e do Sprint 3 Backlog.

--- a/docs/sprints/sprint-2-review.md
+++ b/docs/sprints/sprint-2-review.md
@@ -19,10 +19,11 @@ Demonstrar a consolidacao da base tecnica criada na Sprint 1, com foco em segura
 3. Rodar coverage do backend.
 4. Mostrar a migration da Sprint 2.
 5. Subir backend e frontend.
-6. Demonstrar login/cadastro no prototipo.
-7. Demonstrar abertura, listagem e detalhe de chamado.
-8. Mostrar o workflow de CI no repositório.
-9. Mostrar o status do SonarCloud, se o token ja estiver configurado.
+6. Demonstrar cadastro sem login automatico.
+7. Demonstrar login como usuario e login como tecnico usando as credenciais do seed.
+8. Demonstrar abertura, listagem e detalhe de chamado.
+9. Mostrar o workflow de CI no repositorio.
+10. Mostrar o status do SonarCloud, se o token ja estiver configurado.
 
 ## Pontos em andamento
 

--- a/docs/sprints/sprint-3-planning.md
+++ b/docs/sprints/sprint-3-planning.md
@@ -1,0 +1,32 @@
+# Sprint 3 Planning
+
+## Sprint Goal
+
+Fechar o produto minimo entregavel, documentar a API e preparar a aplicacao para apresentacao final.
+
+## Backlog inicial sugerido
+
+| Item | Descricao | Prioridade |
+| --- | --- | --- |
+| SP3-01 | Completar fluxos do tecnico na interface | Must |
+| SP3-02 | Documentar API com Swagger/OpenAPI ou colecao Postman | Must |
+| SP3-03 | Containerizar aplicacao com Docker e Docker Compose | Must |
+| SP3-04 | Revisar README final com setup completo | Must |
+| SP3-05 | Ampliar testes de integracao da API | Should |
+| SP3-06 | Preparar roteiro da apresentacao final | Should |
+| SP3-07 | Revisar SonarCloud e corrigir code smells prioritarios | Should |
+| SP3-08 | Avaliar deploy gratuito para demonstracao | Could |
+
+## Riscos
+
+- Tempo para integrar frontend e backend em todos os fluxos.
+- Configuracao de ambiente local dos integrantes.
+- Pendencias de qualidade apontadas pelo SonarCloud.
+
+## Definition of Done revisada
+
+- Funcionalidade demonstravel pela interface ou por endpoint documentado.
+- Teste automatizado ou evidencia manual registrada.
+- PR aprovado por outro integrante.
+- CI passando.
+- Documentacao atualizada quando houver mudanca de uso ou arquitetura.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sistema de Chamados</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1672 @@
+{
+  "name": "chamados-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chamados-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "lucide-react": "^0.469.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^6.4.2"
+      }
+    },
+    "..": {
+      "name": "sistema-chamados-suporte",
+      "version": "0.1.0",
+      "extraneous": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
+      "integrity": "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.362",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.362.tgz",
+      "integrity": "sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chamados-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "vite build",
+    "preview": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "lucide-react": "^0.469.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.4.2"
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,15 @@
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { AlertTriangle, LogIn, Plus, RefreshCw, Send, UserPlus } from 'lucide-react';
+import {
+  AlertTriangle,
+  ClipboardList,
+  Headphones,
+  LogIn,
+  Plus,
+  RefreshCw,
+  Send,
+  UserPlus
+} from 'lucide-react';
 import './styles.css';
 
 const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
@@ -229,16 +238,25 @@ function App() {
   }
 
   return (
-    <main className="app-shell">
+    <main className={`app-shell ${isTechnician ? 'technician-mode' : 'requester-mode'}`}>
       <section className="workspace">
         <header className="topbar">
-          <div>
-            <h1>Sistema de Chamados</h1>
+          <div className="brand-lockup">
+            <div className="brand-mark" aria-hidden="true">
+              <Headphones size={22} />
+            </div>
+            <div>
+              <p className="eyebrow">Central de suporte tecnico</p>
+              <h1>Sistema de Chamados</h1>
+            </div>
           </div>
           {auth?.user && (
-            <button className="secondary-action" type="button" onClick={logout}>
-              Sair
-            </button>
+            <div className="session-bar">
+              <span>{auth.user.email}</span>
+              <button className="secondary-action" type="button" onClick={logout}>
+                Sair
+              </button>
+            </div>
           )}
         </header>
 
@@ -263,7 +281,7 @@ function App() {
             }}
           />
         ) : (
-          <div className="dashboard">
+          <div className={`dashboard ${isTechnician ? 'technician-dashboard' : ''}`}>
             <section className="panel">
               <div className="panel-heading">
                 <div>
@@ -328,6 +346,16 @@ function App() {
 function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading, fillCredentials }) {
   return (
     <section className="auth-panel">
+      <div className="auth-heading">
+        <div className="brand-mark" aria-hidden="true">
+          <ClipboardList size={22} />
+        </div>
+        <div>
+          <p className="eyebrow">Acesso</p>
+          <h2>{mode === 'login' ? 'Entrar no sistema' : 'Criar conta'}</h2>
+        </div>
+      </div>
+
       <div className="segmented-control" role="tablist" aria-label="Modo de acesso">
         <button
           className={mode === 'login' ? 'active' : ''}
@@ -351,6 +379,7 @@ function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading, fillCred
         <div className="quick-access" aria-label="Acesso por perfil">
           <button
             type="button"
+            className="quick-access-button"
             onClick={() =>
               fillCredentials({
                 email: 'usuario.demo@example.com',
@@ -362,6 +391,7 @@ function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading, fillCred
           </button>
           <button
             type="button"
+            className="quick-access-button"
             onClick={() =>
               fillCredentials({
                 email: 'tecnico.demo@example.com',
@@ -510,7 +540,10 @@ function TicketList({ tickets, onSelect, isTechnician }) {
               {isTechnician ? ` - ${ticket.requester.name}` : ''}
             </small>
           </span>
-          <span className={`badge ${ticket.status}`}>{ticket.status}</span>
+          <span className="ticket-meta">
+            <span className={`badge priority-${ticket.priority}`}>{ticket.priority}</span>
+            <span className={`badge ${ticket.status}`}>{ticket.status}</span>
+          </span>
         </button>
       ))}
     </div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -13,10 +13,10 @@ const INITIAL_FORM = {
 
 function App() {
   const [mode, setMode] = useStateFromStorage('authMode', 'login');
-  const [auth, setAuth] = useStateFromStorage('auth', null);
+  const [auth, setAuth] = React.useState(null);
   const [authForm, setAuthForm] = React.useState({
-    name: 'Usuario Sprint 2',
-    email: 'usuario.sprint2@example.com',
+    name: '',
+    email: '',
     password: '123456'
   });
   const [ticketForm, setTicketForm] = React.useState(INITIAL_FORM);
@@ -60,18 +60,29 @@ function App() {
     setStatus({ type: 'idle', message: '' });
 
     try {
-      const path = mode === 'login' ? '/api/auth/login' : '/api/auth/register';
-      const payload =
-        mode === 'login'
-          ? { email: authForm.email, password: authForm.password }
-          : { ...authForm };
+      const isLogin = mode === 'login';
+      const path = isLogin ? '/api/auth/login' : '/api/auth/register';
+      const payload = isLogin
+        ? { email: authForm.email, password: authForm.password }
+        : { ...authForm };
       const result = await request(path, {
         method: 'POST',
         body: JSON.stringify(payload)
       });
 
-      setAuth(result);
-      setStatus({ type: 'success', message: 'Usuario autenticado com sucesso.' });
+      if (isLogin) {
+        setAuth(result);
+        setStatus({ type: 'success', message: 'Usuario autenticado com sucesso.' });
+        return;
+      }
+
+      setMode('login');
+      setAuthForm({
+        name: result.user.name,
+        email: result.user.email,
+        password: ''
+      });
+      setStatus({ type: 'success', message: 'Cadastro realizado. Faca login para continuar.' });
     } catch (error) {
       setStatus({ type: 'error', message: error.message });
     } finally {
@@ -149,7 +160,6 @@ function App() {
       <section className="workspace">
         <header className="topbar">
           <div>
-            <p className="eyebrow">Sprint 2</p>
             <h1>Sistema de Chamados</h1>
           </div>
           {auth?.user && (
@@ -174,6 +184,10 @@ function App() {
             setForm={setAuthForm}
             onSubmit={handleAuth}
             isLoading={isLoading}
+            fillCredentials={(credentials) => {
+              setMode('login');
+              setAuthForm({ name: '', ...credentials });
+            }}
           />
         ) : (
           <div className="dashboard">
@@ -224,7 +238,7 @@ function App() {
   );
 }
 
-function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading }) {
+function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading, fillCredentials }) {
   return (
     <section className="auth-panel">
       <div className="segmented-control" role="tablist" aria-label="Modo de acesso">
@@ -245,6 +259,33 @@ function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading }) {
           Cadastro
         </button>
       </div>
+
+      {mode === 'login' && (
+        <div className="quick-access" aria-label="Acesso por perfil">
+          <button
+            type="button"
+            onClick={() =>
+              fillCredentials({
+                email: 'usuario.demo@example.com',
+                password: '123456'
+              })
+            }
+          >
+            Usuario
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              fillCredentials({
+                email: 'tecnico.demo@example.com',
+                password: '123456'
+              })
+            }
+          >
+            Tecnico
+          </button>
+        </div>
+      )}
 
       <form className="form-grid" onSubmit={onSubmit}>
         {mode === 'register' && (

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,14 @@ const INITIAL_FORM = {
   categoryId: '',
   priority: 'medium'
 };
+const STATUS_OPTIONS = [
+  ['open', 'Aberto'],
+  ['in_progress', 'Em atendimento'],
+  ['waiting_user', 'Aguardando usuario'],
+  ['resolved', 'Resolvido'],
+  ['closed', 'Fechado'],
+  ['canceled', 'Cancelado']
+];
 
 function App() {
   const [mode, setMode] = useStateFromStorage('authMode', 'login');
@@ -20,6 +28,7 @@ function App() {
     password: '123456'
   });
   const [ticketForm, setTicketForm] = React.useState(INITIAL_FORM);
+  const [message, setMessage] = React.useState('');
   const [categories, setCategories] = React.useState([]);
   const [tickets, setTickets] = React.useState([]);
   const [selectedTicket, setSelectedTicket] = React.useState(null);
@@ -27,6 +36,7 @@ function App() {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const token = auth?.token;
+  const isTechnician = ['technician', 'admin'].includes(auth?.user?.role);
 
   React.useEffect(() => {
     if (!token) {
@@ -136,6 +146,69 @@ function App() {
     }
   }
 
+  async function assignSelectedTicket() {
+    if (!selectedTicket) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await request(`/api/tickets/${selectedTicket.id}/assign`, {
+        method: 'POST'
+      });
+      await loadWorkspaceData();
+      await showTicket(result.ticket.id);
+      setStatus({ type: 'success', message: 'Chamado assumido pelo tecnico.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function updateSelectedStatus(status) {
+    if (!selectedTicket) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await request(`/api/tickets/${selectedTicket.id}/status`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status })
+      });
+      await loadWorkspaceData();
+      await showTicket(result.ticket.id);
+      setStatus({ type: 'success', message: 'Status do chamado atualizado.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function sendMessage(event) {
+    event.preventDefault();
+    if (!selectedTicket) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await request(`/api/tickets/${selectedTicket.id}/messages`, {
+        method: 'POST',
+        body: JSON.stringify({ message })
+      });
+      setMessage('');
+      await showTicket(selectedTicket.id);
+      setStatus({ type: 'success', message: 'Resposta registrada no historico.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   async function showTicket(ticketId) {
     setIsLoading(true);
     try {
@@ -196,6 +269,7 @@ function App() {
                 <div>
                   <p className="eyebrow">Usuario autenticado</p>
                   <h2>{auth.user.name}</h2>
+                  <span className="profile-label">{isTechnician ? 'Tecnico' : 'Solicitante'}</span>
                 </div>
                 <button className="icon-action" type="button" onClick={loadWorkspaceData}>
                   <RefreshCw size={18} aria-hidden="true" />
@@ -203,13 +277,17 @@ function App() {
                 </button>
               </div>
 
-              <TicketForm
-                categories={categories}
-                form={ticketForm}
-                setForm={setTicketForm}
-                onSubmit={createTicket}
-                isLoading={isLoading}
-              />
+              {isTechnician ? (
+                <TechnicianSummary tickets={tickets} />
+              ) : (
+                <TicketForm
+                  categories={categories}
+                  form={ticketForm}
+                  setForm={setTicketForm}
+                  onSubmit={createTicket}
+                  isLoading={isLoading}
+                />
+              )}
             </section>
 
             <section className="panel">
@@ -219,7 +297,7 @@ function App() {
                   <h2>{tickets.length} registrados</h2>
                 </div>
               </div>
-              <TicketList tickets={tickets} onSelect={showTicket} />
+              <TicketList tickets={tickets} onSelect={showTicket} isTechnician={isTechnician} />
             </section>
 
             <section className="panel detail-panel">
@@ -229,7 +307,16 @@ function App() {
                   <h2>{selectedTicket ? selectedTicket.title : 'Nenhum chamado selecionado'}</h2>
                 </div>
               </div>
-              <TicketDetail ticket={selectedTicket} />
+              <TicketDetail
+                ticket={selectedTicket}
+                isTechnician={isTechnician}
+                isLoading={isLoading}
+                message={message}
+                setMessage={setMessage}
+                onAssign={assignSelectedTicket}
+                onStatusChange={updateSelectedStatus}
+                onSendMessage={sendMessage}
+              />
             </section>
           </div>
         )}
@@ -382,7 +469,32 @@ function TicketForm({ categories, form, setForm, onSubmit, isLoading }) {
   );
 }
 
-function TicketList({ tickets, onSelect }) {
+function TechnicianSummary({ tickets }) {
+  const openCount = tickets.filter((ticket) => ticket.status === 'open').length;
+  const inProgressCount = tickets.filter((ticket) => ticket.status === 'in_progress').length;
+  const highPriorityCount = tickets.filter((ticket) =>
+    ['high', 'critical'].includes(ticket.priority)
+  ).length;
+
+  return (
+    <div className="summary-grid">
+      <article>
+        <span>Abertos</span>
+        <strong>{openCount}</strong>
+      </article>
+      <article>
+        <span>Em atendimento</span>
+        <strong>{inProgressCount}</strong>
+      </article>
+      <article>
+        <span>Alta prioridade</span>
+        <strong>{highPriorityCount}</strong>
+      </article>
+    </div>
+  );
+}
+
+function TicketList({ tickets, onSelect, isTechnician }) {
   if (!tickets.length) {
     return <p className="empty-state">Nenhum chamado encontrado.</p>;
   }
@@ -393,7 +505,10 @@ function TicketList({ tickets, onSelect }) {
         <button key={ticket.id} className="ticket-row" type="button" onClick={() => onSelect(ticket.id)}>
           <span>
             <strong>{ticket.title}</strong>
-            <small>{ticket.category.name} - {ticket.priority}</small>
+            <small>
+              {ticket.category.name} - {ticket.priority}
+              {isTechnician ? ` - ${ticket.requester.name}` : ''}
+            </small>
           </span>
           <span className={`badge ${ticket.status}`}>{ticket.status}</span>
         </button>
@@ -402,7 +517,16 @@ function TicketList({ tickets, onSelect }) {
   );
 }
 
-function TicketDetail({ ticket }) {
+function TicketDetail({
+  ticket,
+  isTechnician,
+  isLoading,
+  message,
+  setMessage,
+  onAssign,
+  onStatusChange,
+  onSendMessage
+}) {
   if (!ticket) {
     return <p className="empty-state">Selecione um chamado para ver o historico.</p>;
   }
@@ -424,6 +548,44 @@ function TicketDetail({ ticket }) {
         </div>
       </dl>
       <p>{ticket.description}</p>
+      {isTechnician && (
+        <div className="technician-actions">
+          {!ticket.technician && (
+            <button className="primary-action" type="button" onClick={onAssign} disabled={isLoading}>
+              Assumir chamado
+            </button>
+          )}
+          <label>
+            Status
+            <select
+              value={ticket.status}
+              onChange={(event) => onStatusChange(event.target.value)}
+              disabled={isLoading}
+            >
+              {STATUS_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <form className="message-form" onSubmit={onSendMessage}>
+            <label>
+              Resposta ao solicitante
+              <textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                rows={3}
+                required
+              />
+            </label>
+            <button className="primary-action" type="submit" disabled={isLoading}>
+              <Send size={18} aria-hidden="true" />
+              Enviar resposta
+            </button>
+          </form>
+        </div>
+      )}
       <div className="timeline">
         {ticket.events?.map((event) => (
           <article key={event.id}>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,420 @@
+import React, { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AlertTriangle, LogIn, Plus, RefreshCw, Send, UserPlus } from 'lucide-react';
+import './styles.css';
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
+const INITIAL_FORM = {
+  title: '',
+  description: '',
+  categoryId: '',
+  priority: 'medium'
+};
+
+function App() {
+  const [mode, setMode] = useStateFromStorage('authMode', 'login');
+  const [auth, setAuth] = useStateFromStorage('auth', null);
+  const [authForm, setAuthForm] = React.useState({
+    name: 'Usuario Sprint 2',
+    email: 'usuario.sprint2@example.com',
+    password: '123456'
+  });
+  const [ticketForm, setTicketForm] = React.useState(INITIAL_FORM);
+  const [categories, setCategories] = React.useState([]);
+  const [tickets, setTickets] = React.useState([]);
+  const [selectedTicket, setSelectedTicket] = React.useState(null);
+  const [status, setStatus] = React.useState({ type: 'idle', message: '' });
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const token = auth?.token;
+
+  React.useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    loadWorkspaceData();
+  }, [token]);
+
+  async function request(path, options = {}) {
+    const response = await fetch(`${API_URL}${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...options.headers
+      }
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data.error?.message ?? 'Falha ao chamar a API.');
+    }
+
+    return data;
+  }
+
+  async function handleAuth(event) {
+    event.preventDefault();
+    setIsLoading(true);
+    setStatus({ type: 'idle', message: '' });
+
+    try {
+      const path = mode === 'login' ? '/api/auth/login' : '/api/auth/register';
+      const payload =
+        mode === 'login'
+          ? { email: authForm.email, password: authForm.password }
+          : { ...authForm };
+      const result = await request(path, {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      });
+
+      setAuth(result);
+      setStatus({ type: 'success', message: 'Usuario autenticado com sucesso.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function loadWorkspaceData() {
+    setIsLoading(true);
+    try {
+      const [categoryResult, ticketResult] = await Promise.all([
+        request('/api/categories'),
+        request('/api/tickets')
+      ]);
+
+      setCategories(categoryResult.categories);
+      setTickets(ticketResult.tickets);
+      setTicketForm((current) => ({
+        ...current,
+        categoryId: current.categoryId || categoryResult.categories[0]?.id || ''
+      }));
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function createTicket(event) {
+    event.preventDefault();
+    setIsLoading(true);
+    setStatus({ type: 'idle', message: '' });
+
+    try {
+      const result = await request('/api/tickets', {
+        method: 'POST',
+        body: JSON.stringify(ticketForm)
+      });
+
+      setSelectedTicket(result.ticket);
+      setTicketForm({
+        ...INITIAL_FORM,
+        categoryId: ticketForm.categoryId
+      });
+      await loadWorkspaceData();
+      setStatus({ type: 'success', message: 'Chamado criado e listado.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function showTicket(ticketId) {
+    setIsLoading(true);
+    try {
+      const result = await request(`/api/tickets/${ticketId}`);
+      setSelectedTicket(result.ticket);
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function logout() {
+    setAuth(null);
+    setTickets([]);
+    setSelectedTicket(null);
+    setStatus({ type: 'idle', message: '' });
+  }
+
+  return (
+    <main className="app-shell">
+      <section className="workspace">
+        <header className="topbar">
+          <div>
+            <p className="eyebrow">Sprint 2</p>
+            <h1>Sistema de Chamados</h1>
+          </div>
+          {auth?.user && (
+            <button className="secondary-action" type="button" onClick={logout}>
+              Sair
+            </button>
+          )}
+        </header>
+
+        {status.message && (
+          <div className={`status ${status.type}`} role="status">
+            <AlertTriangle size={18} aria-hidden="true" />
+            <span>{status.message}</span>
+          </div>
+        )}
+
+        {!auth ? (
+          <AuthPanel
+            mode={mode}
+            setMode={setMode}
+            form={authForm}
+            setForm={setAuthForm}
+            onSubmit={handleAuth}
+            isLoading={isLoading}
+          />
+        ) : (
+          <div className="dashboard">
+            <section className="panel">
+              <div className="panel-heading">
+                <div>
+                  <p className="eyebrow">Usuario autenticado</p>
+                  <h2>{auth.user.name}</h2>
+                </div>
+                <button className="icon-action" type="button" onClick={loadWorkspaceData}>
+                  <RefreshCw size={18} aria-hidden="true" />
+                  <span>Atualizar</span>
+                </button>
+              </div>
+
+              <TicketForm
+                categories={categories}
+                form={ticketForm}
+                setForm={setTicketForm}
+                onSubmit={createTicket}
+                isLoading={isLoading}
+              />
+            </section>
+
+            <section className="panel">
+              <div className="panel-heading">
+                <div>
+                  <p className="eyebrow">Chamados</p>
+                  <h2>{tickets.length} registrados</h2>
+                </div>
+              </div>
+              <TicketList tickets={tickets} onSelect={showTicket} />
+            </section>
+
+            <section className="panel detail-panel">
+              <div className="panel-heading">
+                <div>
+                  <p className="eyebrow">Detalhe</p>
+                  <h2>{selectedTicket ? selectedTicket.title : 'Nenhum chamado selecionado'}</h2>
+                </div>
+              </div>
+              <TicketDetail ticket={selectedTicket} />
+            </section>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function AuthPanel({ mode, setMode, form, setForm, onSubmit, isLoading }) {
+  return (
+    <section className="auth-panel">
+      <div className="segmented-control" role="tablist" aria-label="Modo de acesso">
+        <button
+          className={mode === 'login' ? 'active' : ''}
+          type="button"
+          onClick={() => setMode('login')}
+        >
+          <LogIn size={18} aria-hidden="true" />
+          Login
+        </button>
+        <button
+          className={mode === 'register' ? 'active' : ''}
+          type="button"
+          onClick={() => setMode('register')}
+        >
+          <UserPlus size={18} aria-hidden="true" />
+          Cadastro
+        </button>
+      </div>
+
+      <form className="form-grid" onSubmit={onSubmit}>
+        {mode === 'register' && (
+          <label>
+            Nome
+            <input
+              value={form.name}
+              onChange={(event) => setForm({ ...form, name: event.target.value })}
+              required
+            />
+          </label>
+        )}
+        <label>
+          E-mail
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm({ ...form, email: event.target.value })}
+            required
+          />
+        </label>
+        <label>
+          Senha
+          <input
+            type="password"
+            value={form.password}
+            onChange={(event) => setForm({ ...form, password: event.target.value })}
+            minLength={6}
+            required
+          />
+        </label>
+        <button className="primary-action" type="submit" disabled={isLoading}>
+          {mode === 'login' ? <LogIn size={18} aria-hidden="true" /> : <UserPlus size={18} aria-hidden="true" />}
+          {mode === 'login' ? 'Entrar' : 'Cadastrar'}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function TicketForm({ categories, form, setForm, onSubmit, isLoading }) {
+  return (
+    <form className="form-grid" onSubmit={onSubmit}>
+      <label>
+        Titulo
+        <input
+          value={form.title}
+          onChange={(event) => setForm({ ...form, title: event.target.value })}
+          required
+        />
+      </label>
+      <label>
+        Descricao
+        <textarea
+          value={form.description}
+          onChange={(event) => setForm({ ...form, description: event.target.value })}
+          rows={5}
+          required
+        />
+      </label>
+      <div className="form-row">
+        <label>
+          Categoria
+          <select
+            value={form.categoryId}
+            onChange={(event) => setForm({ ...form, categoryId: event.target.value })}
+            required
+          >
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Prioridade
+          <select
+            value={form.priority}
+            onChange={(event) => setForm({ ...form, priority: event.target.value })}
+          >
+            <option value="low">Baixa</option>
+            <option value="medium">Media</option>
+            <option value="high">Alta</option>
+            <option value="critical">Critica</option>
+          </select>
+        </label>
+      </div>
+      <button className="primary-action" type="submit" disabled={isLoading}>
+        <Plus size={18} aria-hidden="true" />
+        Abrir chamado
+      </button>
+    </form>
+  );
+}
+
+function TicketList({ tickets, onSelect }) {
+  if (!tickets.length) {
+    return <p className="empty-state">Nenhum chamado encontrado.</p>;
+  }
+
+  return (
+    <div className="ticket-list">
+      {tickets.map((ticket) => (
+        <button key={ticket.id} className="ticket-row" type="button" onClick={() => onSelect(ticket.id)}>
+          <span>
+            <strong>{ticket.title}</strong>
+            <small>{ticket.category.name} - {ticket.priority}</small>
+          </span>
+          <span className={`badge ${ticket.status}`}>{ticket.status}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TicketDetail({ ticket }) {
+  if (!ticket) {
+    return <p className="empty-state">Selecione um chamado para ver o historico.</p>;
+  }
+
+  return (
+    <div className="ticket-detail">
+      <dl>
+        <div>
+          <dt>Status</dt>
+          <dd>{ticket.status}</dd>
+        </div>
+        <div>
+          <dt>Prioridade</dt>
+          <dd>{ticket.priority}</dd>
+        </div>
+        <div>
+          <dt>Categoria</dt>
+          <dd>{ticket.category.name}</dd>
+        </div>
+      </dl>
+      <p>{ticket.description}</p>
+      <div className="timeline">
+        {ticket.events?.map((event) => (
+          <article key={event.id}>
+            <Send size={16} aria-hidden="true" />
+            <span>{event.message}</span>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function useStateFromStorage(key, initialValue) {
+  const [value, setValue] = React.useState(() => {
+    const stored = window.localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : initialValue;
+  });
+
+  React.useEffect(() => {
+    if (value === null) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,6 +5,16 @@
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
   line-height: 1.5;
+  --surface: #ffffff;
+  --surface-soft: #f7fafc;
+  --line: #d9e2e8;
+  --line-strong: #c5d1d9;
+  --text-muted: #5c6b77;
+  --brand: #0f766e;
+  --brand-strong: #0b5f59;
+  --ink: #17202a;
+  --blue: #2563eb;
+  --amber: #b7791f;
 }
 
 * {
@@ -30,50 +40,94 @@ button {
 .app-shell {
   min-height: 100vh;
   background:
-    linear-gradient(180deg, #f7f9fb 0%, #eef2f5 42%, #e7edf1 100%);
-  padding: 24px;
+    linear-gradient(180deg, #f8fbfd 0%, #eef3f6 48%, #e6ecef 100%);
+  padding: 28px;
 }
 
 .workspace {
-  width: min(1180px, 100%);
+  width: min(1240px, 100%);
   margin: 0 auto;
 }
 
 .topbar {
   align-items: center;
+  background: rgb(255 255 255 / 78%);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgb(24 39 54 / 8%);
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 18px;
+  padding: 16px 18px;
 }
 
 .topbar h1,
-.panel h2 {
+.panel h2,
+.auth-heading h2 {
   margin: 0;
   letter-spacing: 0;
 }
 
 .topbar h1 {
-  font-size: 32px;
+  font-size: 28px;
   line-height: 1.1;
 }
 
-.panel h2 {
+.panel h2,
+.auth-heading h2 {
   font-size: 18px;
 }
 
+.brand-lockup,
+.auth-heading,
+.session-bar {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.brand-mark {
+  align-items: center;
+  background: #e8f5f2;
+  border: 1px solid #bfe2d8;
+  border-radius: 8px;
+  color: var(--brand-strong);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 46px;
+  justify-content: center;
+  width: 46px;
+}
+
+.session-bar {
+  color: var(--text-muted);
+  font-size: 14px;
+  min-width: 0;
+}
+
+.session-bar span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .profile-label {
-  color: #0f766e;
+  background: #e8f5f2;
+  border: 1px solid #bfe2d8;
+  border-radius: 999px;
+  color: var(--brand-strong);
   display: inline-block;
   font-size: 13px;
   font-weight: 800;
-  margin-top: 4px;
+  margin-top: 6px;
+  padding: 3px 9px;
 }
 
 .eyebrow {
-  color: #55616d;
+  color: var(--text-muted);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0;
   margin: 0 0 4px;
   text-transform: uppercase;
@@ -81,23 +135,27 @@ button {
 
 .auth-panel,
 .panel {
-  background: #ffffff;
-  border: 1px solid #d9e1e7;
+  background: var(--surface);
+  border: 1px solid var(--line);
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgb(24 39 54 / 8%);
+  box-shadow: 0 10px 28px rgb(24 39 54 / 7%);
 }
 
 .auth-panel {
-  margin: 48px auto 0;
+  margin: 42px auto 0;
   max-width: 520px;
-  padding: 24px;
+  padding: 26px;
 }
 
 .dashboard {
   align-items: start;
   display: grid;
   gap: 16px;
-  grid-template-columns: minmax(320px, 0.95fr) minmax(320px, 1fr);
+  grid-template-columns: minmax(340px, 0.9fr) minmax(360px, 1.1fr);
+}
+
+.technician-dashboard {
+  grid-template-columns: minmax(360px, 0.75fr) minmax(420px, 1.25fr);
 }
 
 .detail-panel {
@@ -105,7 +163,7 @@ button {
 }
 
 .panel {
-  padding: 20px;
+  padding: 22px;
 }
 
 .panel-heading {
@@ -114,11 +172,12 @@ button {
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 18px;
+  min-height: 48px;
 }
 
 .segmented-control {
-  background: #e8edf1;
-  border: 1px solid #ccd6dd;
+  background: #edf3f6;
+  border: 1px solid var(--line-strong);
   border-radius: 8px;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -135,12 +194,17 @@ button {
 }
 
 .quick-access button {
-  background: #f6f8fa;
-  border: 1px solid #cbd5dc;
+  background: var(--surface-soft);
+  border: 1px solid var(--line-strong);
   border-radius: 6px;
-  color: #17202a;
+  color: var(--ink);
   font-weight: 700;
   min-height: 40px;
+}
+
+.quick-access button:hover {
+  border-color: var(--brand);
+  color: var(--brand-strong);
 }
 
 .segmented-control button,
@@ -164,15 +228,19 @@ button {
 }
 
 .segmented-control button.active {
-  background: #ffffff;
-  color: #0f3b4f;
+  background: var(--surface);
+  color: var(--brand-strong);
   box-shadow: 0 2px 8px rgb(24 39 54 / 10%);
 }
 
 .primary-action {
-  background: #0f766e;
+  background: var(--brand);
   color: #ffffff;
   font-weight: 700;
+}
+
+.primary-action:hover {
+  background: var(--brand-strong);
 }
 
 .primary-action:disabled {
@@ -182,14 +250,15 @@ button {
 
 .secondary-action,
 .icon-action {
-  background: #17202a;
+  background: var(--ink);
   color: #ffffff;
   font-weight: 700;
 }
 
 .icon-action {
   background: #eef4f7;
-  color: #17202a;
+  border: 1px solid var(--line);
+  color: var(--ink);
 }
 
 .form-grid {
@@ -223,6 +292,14 @@ textarea {
   width: 100%;
 }
 
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgb(15 118 110 / 14%);
+  outline: none;
+}
+
 textarea {
   resize: vertical;
 }
@@ -251,6 +328,9 @@ textarea {
 .ticket-list {
   display: grid;
   gap: 10px;
+  max-height: 540px;
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .summary-grid {
@@ -260,14 +340,14 @@ textarea {
 }
 
 .summary-grid article {
-  background: #f6f8fa;
-  border: 1px solid #dce4ea;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
   border-radius: 8px;
   padding: 14px;
 }
 
 .summary-grid span {
-  color: #607080;
+  color: var(--text-muted);
   display: block;
   font-size: 12px;
   font-weight: 800;
@@ -283,16 +363,22 @@ textarea {
 
 .ticket-row {
   align-items: center;
-  background: #fbfcfd;
-  border: 1px solid #d7e0e6;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
   border-radius: 8px;
   color: inherit;
   display: flex;
   justify-content: space-between;
-  min-height: 72px;
-  padding: 12px;
+  gap: 12px;
+  min-height: 76px;
+  padding: 14px;
   text-align: left;
   width: 100%;
+}
+
+.ticket-row:hover {
+  border-color: #9fc8bd;
+  box-shadow: 0 6px 16px rgb(24 39 54 / 8%);
 }
 
 .ticket-row strong,
@@ -301,14 +387,21 @@ textarea {
 }
 
 .ticket-row small {
-  color: #607080;
+  color: var(--text-muted);
   margin-top: 2px;
+}
+
+.ticket-meta {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .badge {
   background: #e8edf1;
   border-radius: 999px;
-  color: #17202a;
+  color: var(--ink);
   font-size: 12px;
   font-weight: 800;
   padding: 5px 9px;
@@ -331,9 +424,29 @@ textarea {
   color: #12603b;
 }
 
+.badge.priority-low {
+  background: #edf7ed;
+  color: #1f6b36;
+}
+
+.badge.priority-medium {
+  background: #eaf2ff;
+  color: #174a7c;
+}
+
+.badge.priority-high {
+  background: #fff1d6;
+  color: var(--amber);
+}
+
+.badge.priority-critical {
+  background: #ffe4e0;
+  color: #9d2519;
+}
+
 .ticket-detail {
   display: grid;
-  gap: 14px;
+  gap: 16px;
 }
 
 .ticket-detail dl {
@@ -344,14 +457,14 @@ textarea {
 }
 
 .ticket-detail dl div {
-  background: #f6f8fa;
-  border: 1px solid #dce4ea;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
   border-radius: 8px;
   padding: 12px;
 }
 
 .ticket-detail dt {
-  color: #607080;
+  color: var(--text-muted);
   font-size: 12px;
   font-weight: 700;
   margin-bottom: 4px;
@@ -370,10 +483,12 @@ textarea {
 }
 
 .technician-actions {
-  border-top: 1px solid #dce4ea;
+  background: #f8fbfb;
+  border: 1px solid var(--line);
+  border-radius: 8px;
   display: grid;
   gap: 12px;
-  padding-top: 14px;
+  padding: 14px;
 }
 
 .message-form {
@@ -389,7 +504,7 @@ textarea {
 .timeline article {
   align-items: center;
   background: #f9fbfc;
-  border: 1px solid #dce4ea;
+  border: 1px solid var(--line);
   border-radius: 8px;
   display: flex;
   gap: 10px;
@@ -402,10 +517,16 @@ textarea {
   }
 
   .topbar,
+  .brand-lockup,
+  .session-bar,
   .panel-heading,
   .ticket-row {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .session-bar span {
+    white-space: normal;
   }
 
   .dashboard,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -119,6 +119,22 @@ button {
   padding: 4px;
 }
 
+.quick-access {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 18px;
+}
+
+.quick-access button {
+  background: #f6f8fa;
+  border: 1px solid #cbd5dc;
+  border-radius: 6px;
+  color: #17202a;
+  font-weight: 700;
+  min-height: 40px;
+}
+
 .segmented-control button,
 .primary-action,
 .secondary-action,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -62,6 +62,14 @@ button {
   font-size: 18px;
 }
 
+.profile-label {
+  color: #0f766e;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 800;
+  margin-top: 4px;
+}
+
 .eyebrow {
   color: #55616d;
   font-size: 12px;
@@ -245,6 +253,34 @@ textarea {
   gap: 10px;
 }
 
+.summary-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.summary-grid article {
+  background: #f6f8fa;
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.summary-grid span {
+  color: #607080;
+  display: block;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.summary-grid strong {
+  display: block;
+  font-size: 28px;
+  line-height: 1;
+  margin-top: 8px;
+}
+
 .ticket-row {
   align-items: center;
   background: #fbfcfd;
@@ -333,6 +369,18 @@ textarea {
   margin: 0;
 }
 
+.technician-actions {
+  border-top: 1px solid #dce4ea;
+  display: grid;
+  gap: 12px;
+  padding-top: 14px;
+}
+
+.message-form {
+  display: grid;
+  gap: 10px;
+}
+
 .timeline {
   display: grid;
   gap: 8px;
@@ -362,6 +410,7 @@ textarea {
 
   .dashboard,
   .form-row,
+  .summary-grid,
   .ticket-detail dl {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,352 @@
+:root {
+  color: #17202a;
+  background: #eef2f5;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, #f7f9fb 0%, #eef2f5 42%, #e7edf1 100%);
+  padding: 24px;
+}
+
+.workspace {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.topbar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.topbar h1,
+.panel h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.topbar h1 {
+  font-size: 32px;
+  line-height: 1.1;
+}
+
+.panel h2 {
+  font-size: 18px;
+}
+
+.eyebrow {
+  color: #55616d;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.auth-panel,
+.panel {
+  background: #ffffff;
+  border: 1px solid #d9e1e7;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgb(24 39 54 / 8%);
+}
+
+.auth-panel {
+  margin: 48px auto 0;
+  max-width: 520px;
+  padding: 24px;
+}
+
+.dashboard {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(320px, 0.95fr) minmax(320px, 1fr);
+}
+
+.detail-panel {
+  grid-column: 1 / -1;
+}
+
+.panel {
+  padding: 20px;
+}
+
+.panel-heading {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.segmented-control {
+  background: #e8edf1;
+  border: 1px solid #ccd6dd;
+  border-radius: 8px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-bottom: 20px;
+  padding: 4px;
+}
+
+.segmented-control button,
+.primary-action,
+.secondary-action,
+.icon-action {
+  align-items: center;
+  border: 0;
+  border-radius: 6px;
+  display: inline-flex;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 10px 14px;
+}
+
+.segmented-control button {
+  background: transparent;
+  color: #44505c;
+  font-weight: 700;
+}
+
+.segmented-control button.active {
+  background: #ffffff;
+  color: #0f3b4f;
+  box-shadow: 0 2px 8px rgb(24 39 54 / 10%);
+}
+
+.primary-action {
+  background: #0f766e;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.primary-action:disabled {
+  background: #8ab5b0;
+  cursor: not-allowed;
+}
+
+.secondary-action,
+.icon-action {
+  background: #17202a;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.icon-action {
+  background: #eef4f7;
+  color: #17202a;
+}
+
+.form-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.form-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+}
+
+label {
+  color: #35414c;
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  background: #fbfcfd;
+  border: 1px solid #cbd5dc;
+  border-radius: 6px;
+  color: #17202a;
+  min-height: 42px;
+  padding: 10px 12px;
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.status {
+  align-items: center;
+  border-radius: 8px;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 12px 14px;
+}
+
+.status.error {
+  background: #fff1f0;
+  border: 1px solid #ffc9c2;
+  color: #8a1f11;
+}
+
+.status.success {
+  background: #edf8f4;
+  border: 1px solid #bee8d6;
+  color: #0d5f4a;
+}
+
+.ticket-list {
+  display: grid;
+  gap: 10px;
+}
+
+.ticket-row {
+  align-items: center;
+  background: #fbfcfd;
+  border: 1px solid #d7e0e6;
+  border-radius: 8px;
+  color: inherit;
+  display: flex;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 12px;
+  text-align: left;
+  width: 100%;
+}
+
+.ticket-row strong,
+.ticket-row small {
+  display: block;
+}
+
+.ticket-row small {
+  color: #607080;
+  margin-top: 2px;
+}
+
+.badge {
+  background: #e8edf1;
+  border-radius: 999px;
+  color: #17202a;
+  font-size: 12px;
+  font-weight: 800;
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.badge.open {
+  background: #fff4d6;
+  color: #725200;
+}
+
+.badge.in_progress {
+  background: #deecff;
+  color: #174a7c;
+}
+
+.badge.resolved,
+.badge.closed {
+  background: #dff7ea;
+  color: #12603b;
+}
+
+.ticket-detail {
+  display: grid;
+  gap: 14px;
+}
+
+.ticket-detail dl {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0;
+}
+
+.ticket-detail dl div {
+  background: #f6f8fa;
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.ticket-detail dt {
+  color: #607080;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+}
+
+.ticket-detail dd {
+  font-weight: 800;
+  margin: 0;
+}
+
+.ticket-detail p,
+.empty-state {
+  color: #4b5864;
+  margin: 0;
+}
+
+.timeline {
+  display: grid;
+  gap: 8px;
+}
+
+.timeline article {
+  align-items: center;
+  background: #f9fbfc;
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    padding: 16px;
+  }
+
+  .topbar,
+  .panel-heading,
+  .ticket-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dashboard,
+  .form-row,
+  .ticket-detail dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:backend": "npm --prefix backend run dev",
     "dev:frontend": "npm --prefix frontend run dev",
     "build:frontend": "npm --prefix frontend run build",
+    "seed:demo": "npm --prefix backend run seed:demo",
     "test": "npm --prefix backend test",
     "coverage": "npm --prefix backend run coverage"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "Sistema web para gerenciamento de chamados de suporte tecnico.",
   "scripts": {
     "install:backend": "npm --prefix backend install",
+    "install:frontend": "npm --prefix frontend install",
     "dev:backend": "npm --prefix backend run dev",
+    "dev:frontend": "npm --prefix frontend run dev",
+    "build:frontend": "npm --prefix frontend run build",
     "test": "npm --prefix backend test",
     "coverage": "npm --prefix backend run coverage"
   }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=leoguimaraes49_projeto-integrador-chamados
+sonar.organization=leoguimaraes49
+sonar.projectName=Sistema de Gerenciamento de Chamados
+
+sonar.sources=backend/src,frontend/src
+sonar.tests=backend/tests
+sonar.test.inclusions=backend/tests/**/*.test.js
+sonar.javascript.lcov.reportPaths=backend/coverage/lcov.info
+sonar.coverage.exclusions=backend/src/app.js,backend/src/config/**,backend/src/db/**,backend/src/middleware/**,backend/src/repositories/**,backend/src/routes/**,backend/src/server.js,frontend/src/**


### PR DESCRIPTION
## Resumo
- adiciona seguranca basica na API com Helmet, CORS local e rate limit em autenticacao
- adiciona migration versionada da Sprint 2 e seed de usuarios demo
- cria prototipo React com telas para solicitante e tecnico
- adiciona CI com migrations, testes, coverage, build frontend e preparacao SonarCloud
- documenta checklist, review, retrospectiva e planejamento da Sprint 3

## Validacao local
- npm.cmd --prefix backend test
- npm.cmd --prefix backend run coverage
- npm.cmd --prefix frontend run build
- npm.cmd --prefix backend audit --audit-level=moderate
- npm.cmd --prefix frontend audit --audit-level=moderate

## Observacoes
- Docker, RabbitMQ e deploy continuam fora da Sprint 2.
- SonarCloud depende do segredo SONAR_TOKEN no GitHub.